### PR TITLE
【Laravel】お気に入り登録/解除API作成

### DIFF
--- a/frontend/features/Home/FavoriteFacility/index.tsx
+++ b/frontend/features/Home/FavoriteFacility/index.tsx
@@ -24,7 +24,7 @@ export const FavoriteFacilities = ({ facilityFavorities }: Props): React.JSX.Ele
           <FacilityFavoriteCard facility={facilityFavorities[0]} />
         </div>
       )}
-      {facilityFavorities.length === 2 && (
+      {facilityFavorities.length >= 2 && (
         <div className="overflow-x-auto pb-2">
           <div className="flex gap-6 min-w-fit mx-auto px-2">
             {facilityFavorities.map((facilityFavority, i) => (

--- a/frontend/features/Home/FavoriteFacility/index.tsx
+++ b/frontend/features/Home/FavoriteFacility/index.tsx
@@ -9,25 +9,25 @@ type FacilityFavorite = {
 };
 
 type Props = {
-  facilityFavorities: FacilityFavorite[];
+  facilityFavorites: FacilityFavorite[];
 };
 
-export const FavoriteFacilities = ({ facilityFavorities }: Props): React.JSX.Element => {
+export const FavoriteFacilities = ({ facilityFavorites }: Props): React.JSX.Element => {
   return (
     <div className="w-full max-w-[1200px] mx-auto mt-8">
       <p className="font-bold mb-4">お気に入り施設</p>
-      {facilityFavorities.length === 0 && (
+      {facilityFavorites.length === 0 && (
         <p className="text-center text-gray-500">お気に入り施設はありません。</p>
       )}
-      {facilityFavorities.length === 1 && (
+      {facilityFavorites.length === 1 && (
         <div className="flex justify-center">
-          <FacilityFavoriteCard facility={facilityFavorities[0]} />
+          <FacilityFavoriteCard facility={facilityFavorites[0]} />
         </div>
       )}
-      {facilityFavorities.length >= 2 && (
+      {facilityFavorites.length >= 2 && (
         <div className="overflow-x-auto pb-2">
           <div className="flex gap-6 min-w-fit mx-auto px-2">
-            {facilityFavorities.map((facilityFavority, i) => (
+            {facilityFavorites.map((facilityFavority, i) => (
               <FacilityFavoriteCard key={i} facility={facilityFavority} />
             ))}
           </div>

--- a/frontend/features/Home/index.tsx
+++ b/frontend/features/Home/index.tsx
@@ -19,7 +19,7 @@ type FacilityFavorite = {
 
 export const Home = (): React.JSX.Element => {
   const [events, setEvents] = useState<ApiEvent[]>([]);
-  const [facilityFavorities, setFacilityFavorities] = useState<FacilityFavorite[]>([]);
+  const [facilityFavorites, setFacilityFavorites] = useState<FacilityFavorite[]>([]);
   const [selectedDate, setSelectedDate] = useState<string>(new Date().toISOString().slice(0, 10));
   const [token, setToken] = useState<string | null>(null);
   const today = new Date();
@@ -72,7 +72,7 @@ export const Home = (): React.JSX.Element => {
           headers,
         });
 
-        setFacilityFavorities(resData.data.facilityFavorities);
+        setFacilityFavorites(resData.data.facilityFavorites);
       } catch (error) {
         console.error('トップページデータ取得エラー:', error);
       }
@@ -99,7 +99,7 @@ export const Home = (): React.JSX.Element => {
             events={events.filter(ev => ev.start_datetime.slice(0, 10) === selectedDate)}
             selectedDate={selectedDate}
           />
-          <FavoriteFacilities facilityFavorities={facilityFavorities} />
+          <FavoriteFacilities facilityFavorites={facilityFavorites} />
           <div className="w-full bg-pink-300 text-white p-2 rounded mt-6">
             <div className="flex justify-center">
               <button className="font-semibold px-6 py-2 rounded">施設を探す</button>

--- a/laravel/app/Exceptions/Handler.php
+++ b/laravel/app/Exceptions/Handler.php
@@ -25,7 +25,9 @@ class Handler extends ExceptionHandler
     public function register(): void
     {
         $this->renderable(function (NotFoundHttpException $e, $request) {
-            if (! $request->is('api/*')) return;
+            if (! $request->is('api/*')) {
+                return;
+            }
 
             if (str_contains($e->getMessage(), 'Facility')) {
                 $message = '該当の施設が見つかりません。';

--- a/laravel/app/Exceptions/Handler.php
+++ b/laravel/app/Exceptions/Handler.php
@@ -2,6 +2,7 @@
 
 namespace App\Exceptions;
 
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
 
@@ -23,8 +24,21 @@ class Handler extends ExceptionHandler
      */
     public function register(): void
     {
-        $this->reportable(function (Throwable $e) {
-            //
+        $this->renderable(function (NotFoundHttpException $e, $request) {
+            if (! $request->is('api/*')) return;
+
+            if (str_contains($e->getMessage(), 'Facility')) {
+                $message = '該当の施設が見つかりません。';
+            } elseif (str_contains($e->getMessage(), 'User')) {
+                $message = '該当のユーザーが見つかりません。';
+            } else {
+                $message = 'リソースが見つかりません。';
+            }
+
+            return response()->json([
+                'message' => $message ?? 'リソースが見つかりません。',
+
+            ], 404);
         });
     }
 }

--- a/laravel/app/Http/Controllers/FacilityController.php
+++ b/laravel/app/Http/Controllers/FacilityController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Facility;
 use App\Services\FacilityService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;

--- a/laravel/app/Http/Controllers/FacilityController.php
+++ b/laravel/app/Http/Controllers/FacilityController.php
@@ -77,10 +77,10 @@ class FacilityController extends Controller
         ], 200);
     }
 
-    public function show(Facility $facility)
+    public function show(int $facilityId)
     {
         try {
-            $facilityDetail = $this->facilityService->find($facility->id);
+            $facilityDetail = $this->facilityService->find($facilityId);
             return response()->json(['facility' => $facilityDetail], 200);
         } catch (ModelNotFoundException) {
             return response()->json(['message' => '該当の施設が見つかりません。'], 404);

--- a/laravel/app/Http/Controllers/FacilityController.php
+++ b/laravel/app/Http/Controllers/FacilityController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Facility;
 use App\Services\FacilityService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
@@ -76,11 +77,11 @@ class FacilityController extends Controller
         ], 200);
     }
 
-    public function show($id)
+    public function show(Facility $facility)
     {
         try {
-            $facility = $this->facilityService->find($id);
-            return response()->json(['facility' => $facility], 200);
+            $facilityDetail = $this->facilityService->find($facility->id);
+            return response()->json(['facility' => $facilityDetail], 200);
         } catch (ModelNotFoundException) {
             return response()->json(['message' => '該当の施設が見つかりません。'], 404);
         }

--- a/laravel/app/Http/Controllers/FacilityController.php
+++ b/laravel/app/Http/Controllers/FacilityController.php
@@ -76,7 +76,7 @@ class FacilityController extends Controller
         ], 200);
     }
 
-    public function show(int $facilityId)
+    public function show(string $facilityId)
     {
         try {
             $facilityDetail = $this->facilityService->find($facilityId);

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -21,8 +21,8 @@ class FavoriteController extends Controller
 
     public function index()
     {
-        $facilityFavorities = $this->facilityFavoriteService->getFacilityFavorities();
-        return response()->json(['facilityFavorities' => $facilityFavorities]);
+        $facilityFavorites = $this->facilityFavoriteService->getFacilityFavorites();
+        return response()->json(['facilityFavorites' => $facilityFavorites]);
     }
 
     public function store(int $facilityId)
@@ -33,7 +33,7 @@ class FavoriteController extends Controller
             return response()->json(['message' => '該当の施設が見つかりません。'], 404);
         }
 
-        $this->facilityFavoriteService->registerFacilityFavorite($facility->id);
+        $this->facilityFavoriteService->register($facility->id);
         return response()->json(['message' => 'お気に入り登録しました。'], 201);
     }
 
@@ -45,7 +45,7 @@ class FavoriteController extends Controller
             return response()->json(['message' => '該当の施設が見つかりません。'], 404);
         }
 
-        $this->facilityFavoriteService->cancelFacilityFavorite(($facility->id));
+        $this->facilityFavoriteService->cancel(($facility->id));
         return response()->json(['message' => 'お気に入り解除しました。'], 201);
     }
 }

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -2,10 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Facility;
 use App\Services\FacilityService;
 use App\Services\FacilityFavoriteService;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 
 class FavoriteController extends Controller

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -20,4 +20,10 @@ class FavoriteController extends Controller
         $facilityFavorities = $this->facilityFavoriteService->getFacilityFavorities();
         return response()->json(['facilityFavorities' => $facilityFavorities]);
     }
+
+    public function store($id)
+    {
+        $success = $this->facilityFavoriteService->registerFacilityFavorite($id);
+        return response()->json(['success' => $success], 201);
+    }
 }

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -29,10 +29,6 @@ class FavoriteController extends Controller
     {
         $facility = $this->facilityService->find($facilityId);
 
-        if (! $facility) {
-            return response()->json(['message' => '該当の施設が見つかりません。'], 404);
-        }
-
         $this->facilityFavoriteService->register($facility->id);
         return response()->json(['message' => 'お気に入り登録しました。'], 201);
     }

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -2,17 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Facility;
+use App\Services\FacilityService;
 use App\Services\FacilityFavoriteService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 
 class FavoriteController extends Controller
 {
     protected FacilityFavoriteService $facilityFavoriteService;
+    protected FacilityService $facilityService;
 
     public function __construct(
-        FacilityFavoriteService $facilityFavoriteService
+        FacilityFavoriteService $facilityFavoriteService,
+        FacilityService $facilityService,
     ) {
         $this->facilityFavoriteService = $facilityFavoriteService;
+        $this->facilityService = $facilityService;
     }
 
     public function index()
@@ -21,9 +27,15 @@ class FavoriteController extends Controller
         return response()->json(['facilityFavorities' => $facilityFavorities]);
     }
 
-    public function store($id)
+    public function store(int $facilityId)
     {
-        $success = $this->facilityFavoriteService->registerFacilityFavorite($id);
+        $facility = $this->facilityService->find($facilityId);
+
+        if (! $facility) {
+            return response()->json(['message' => '該当の施設が見つかりません。'], 404);
+        }
+
+        $success = $this->facilityFavoriteService->registerFacilityFavorite($facility->id);
         return response()->json(['success' => $success], 201);
     }
 }

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -25,7 +25,7 @@ class FavoriteController extends Controller
         return response()->json(['facilityFavorites' => $facilityFavorites]);
     }
 
-    public function store(int $facilityId)
+    public function store(string $facilityId)
     {
         $facility = $this->facilityService->find($facilityId);
 
@@ -37,7 +37,7 @@ class FavoriteController extends Controller
         return response()->json(['message' => 'お気に入り登録しました。'], 201);
     }
 
-    public function destroy(int $facilityId)
+    public function destroy(string $facilityId)
     {
         $facility = $this->facilityService->find($facilityId);
 

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -33,7 +33,19 @@ class FavoriteController extends Controller
             return response()->json(['message' => '該当の施設が見つかりません。'], 404);
         }
 
-        $success = $this->facilityFavoriteService->registerFacilityFavorite($facility->id);
-        return response()->json(['success' => $success], 201);
+        $this->facilityFavoriteService->registerFacilityFavorite($facility->id);
+        return response()->json(['message' => 'お気に入り登録しました。'], 201);
+    }
+
+    public function destroy(int $facilityId)
+    {
+        $facility = $this->facilityService->find($facilityId);
+
+        if (! $facility) {
+            return response()->json(['message' => '該当の施設が見つかりません。'], 404);
+        }
+
+        $this->facilityFavoriteService->cancelFacilityFavorite(($facility->id));
+        return response()->json(['message' => 'お気に入り解除しました。'], 201);
     }
 }

--- a/laravel/app/Http/Controllers/FavoriteController.php
+++ b/laravel/app/Http/Controllers/FavoriteController.php
@@ -37,10 +37,6 @@ class FavoriteController extends Controller
     {
         $facility = $this->facilityService->find($facilityId);
 
-        if (! $facility) {
-            return response()->json(['message' => '該当の施設が見つかりません。'], 404);
-        }
-
         $this->facilityFavoriteService->cancel(($facility->id));
         return response()->json(['message' => 'お気に入り解除しました。'], 201);
     }

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -82,7 +82,7 @@ class User extends Authenticatable
                     ->whereNull('user_events.deleted_at');
     }
 
-    public function facilityFavorities()
+    public function facilityFavorites()
     {
         return $this->belongsToMany(Facility::class, 'facility_favorites', 'user_id', 'facility_id')->withTimestamps();
     }

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -84,7 +84,7 @@ class User extends Authenticatable
 
     public function facilityFavorities()
     {
-        return $this->belongsToMany(Facility::class, 'facility_favorites')->withTimestamps();
+        return $this->belongsToMany(Facility::class, 'facility_favorites', 'user_id', 'facility_id')->withTimestamps();
     }
 
     protected static function booted()

--- a/laravel/app/Providers/RepositoryServiceProvider.php
+++ b/laravel/app/Providers/RepositoryServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Repositories\Facility\FacilityRepository;
 use App\Repositories\Facility\FacilityRepositoryInterface;
+use App\Repositories\FacilityFavorite\FacilityFavoriteRepository;
+use App\Repositories\FacilityFavorite\FacilityFavoriteRepositoryInterface;
 use App\Repositories\User\UserRepository;
 use App\Repositories\User\UserRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
@@ -17,6 +19,7 @@ class RepositoryServiceProvider extends ServiceProvider
     {
         $this->app->bind(UserRepositoryInterface::class, UserRepository::class);
         $this->app->bind(FacilityRepositoryInterface::class, FacilityRepository::class);
+        $this->app->bind(FacilityFavoriteRepositoryInterface::class, FacilityFavoriteRepository::class);
     }
 
     /**

--- a/laravel/app/Repositories/Facility/FacilityRepository.php
+++ b/laravel/app/Repositories/Facility/FacilityRepository.php
@@ -20,6 +20,9 @@ class FacilityRepository implements FacilityRepositoryInterface
     {
         return $this->facility
                     ->with(['address.municipality.prefecture'])
+                    ->whereHas('address', function ($q) use ($municipalityId) {
+                            $q->where('municipality_id', $municipalityId);
+                        })
                     ->when($name, fn ($q) => $q->where('name', 'LIKE', "%{$name}%"))
                     ->get();
     }

--- a/laravel/app/Repositories/Facility/FacilityRepository.php
+++ b/laravel/app/Repositories/Facility/FacilityRepository.php
@@ -20,12 +20,7 @@ class FacilityRepository implements FacilityRepositoryInterface
     {
         return $this->facility
                     ->with(['address.municipality.prefecture'])
-                    ->whereHas("address", function ($query) use ($municipalityId) {
-                        $query->where("municipality_id", $municipalityId);
-                    })
-                    ->when($name, function (Builder $query, string $name) {
-                        $query->where('name', 'LIKE', "%{$name}%");
-                    })
+                    ->when($name, fn ($q) => $q->where('name', 'LIKE', "%{$name}%"))
                     ->get();
     }
 

--- a/laravel/app/Repositories/Facility/FacilityRepository.php
+++ b/laravel/app/Repositories/Facility/FacilityRepository.php
@@ -27,7 +27,7 @@ class FacilityRepository implements FacilityRepositoryInterface
                     ->get();
     }
 
-    public function find(int $id): Facility
+    public function find(string $id): Facility
     {
         return $this->facility
                     ->with(['hours', 'phone', 'reviews.user', 'address.municipality.prefecture'])

--- a/laravel/app/Repositories/Facility/FacilityRepository.php
+++ b/laravel/app/Repositories/Facility/FacilityRepository.php
@@ -21,8 +21,8 @@ class FacilityRepository implements FacilityRepositoryInterface
         return $this->facility
                     ->with(['address.municipality.prefecture'])
                     ->whereHas('address', function ($q) use ($municipalityId) {
-                            $q->where('municipality_id', $municipalityId);
-                        })
+                        $q->where('municipality_id', $municipalityId);
+                    })
                     ->when($name, fn ($q) => $q->where('name', 'LIKE', "%{$name}%"))
                     ->get();
     }

--- a/laravel/app/Repositories/Facility/FacilityRepositoryInterface.php
+++ b/laravel/app/Repositories/Facility/FacilityRepositoryInterface.php
@@ -8,5 +8,5 @@ use Illuminate\Database\Eloquent\Collection;
 interface FacilityRepositoryInterface
 {
     public function getAll(int $municipalityId, ?string $name): Collection;
-    public function find(int $id): Facility;
+    public function find(string $id): Facility;
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
@@ -20,12 +20,12 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
         return $this->user->findOrFail($userId)->facilityFavorites()->get();
     }
 
-    public function register(int $facilityId, int $userId): void
+    public function register(string $facilityId, int $userId): void
     {
         $this->user->findOrFail($userId)->facilityFavorites()->syncWithoutDetaching($facilityId);
     }
 
-    public function cancel(int $facilityId, int $userId): void
+    public function cancel(string $facilityId, int $userId): void
     {
         $this->user->findOrFail($userId)->facilityFavorites()->detach($facilityId);
     }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
@@ -19,4 +19,11 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
     {
         return $this->user->findOrFail($userId)->facilityFavorities()->get();
     }
+
+    public function registerUserFacilityFavorite(int $facilityId, int $userId): bool
+    {
+        $this->user->findOrFail($userId)->facilityFavorities()->syncWithoutDetaching([$facilityId]);
+
+        return true;
+    }
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
@@ -22,7 +22,14 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
 
     public function registerUserFacilityFavorite(int $facilityId, int $userId): bool
     {
-        $this->user->findOrFail($userId)->facilityFavorities()->syncWithoutDetaching([$facilityId]);
+        $this->user->findOrFail($userId)->facilityFavorities()->syncWithoutDetaching($facilityId);
+
+        return true;
+    }
+
+    public function cancelUserFacilityFavorite(int $facilityId, int $userId): bool
+    {
+        $this->user->findOrFail($userId)->facilityFavorities()->detach($facilityId);
 
         return true;
     }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
@@ -17,7 +17,7 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
 
     public function getUserFacilityFavorites(int $userId): Collection
     {
-        return $this->user->findOrFail($userId)->facilityFavorities()->get();
+        return $this->user->findOrFail($userId)->facilityFavorites()->get();
     }
 
     public function register(int $facilityId, int $userId): void
@@ -27,6 +27,6 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
 
     public function cancel(int $facilityId, int $userId): void
     {
-        $this->user->findOrFail($userId)->facilityFavorities()->detach($facilityId);
+        $this->user->findOrFail($userId)->facilityFavorites()->detach($facilityId);
     }
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
@@ -22,7 +22,7 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
 
     public function registerUserFacilityFavorite(int $facilityId, int $userId): bool
     {
-        $this->user->findOrFail($userId)->facilityFavorities()->syncWithoutDetaching($facilityId);
+        $this->user->findOrFail($userId)->facilityFavorites()->syncWithoutDetaching($facilityId);
 
         return true;
     }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepository.php
@@ -15,22 +15,18 @@ class FacilityFavoriteRepository implements FacilityFavoriteRepositoryInterface
         $this->user = $user;
     }
 
-    public function getUserFacilityFavorities(int $userId): Collection
+    public function getUserFacilityFavorites(int $userId): Collection
     {
         return $this->user->findOrFail($userId)->facilityFavorities()->get();
     }
 
-    public function registerUserFacilityFavorite(int $facilityId, int $userId): bool
+    public function register(int $facilityId, int $userId): void
     {
         $this->user->findOrFail($userId)->facilityFavorites()->syncWithoutDetaching($facilityId);
-
-        return true;
     }
 
-    public function cancelUserFacilityFavorite(int $facilityId, int $userId): bool
+    public function cancel(int $facilityId, int $userId): void
     {
         $this->user->findOrFail($userId)->facilityFavorities()->detach($facilityId);
-
-        return true;
     }
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
@@ -7,6 +7,6 @@ use Illuminate\Database\Eloquent\Collection;
 interface FacilityFavoriteRepositoryInterface
 {
     public function getUserFacilityFavorites(int $id): Collection;
-    public function registerUserFacilityFavorite(int $facilityId, int $userId): bool;
-    public function cancelUserFacilityFavorite(int $facilityId, int $userId): bool;
+    public function register(int $facilityId, int $userId): void;
+    public function cancel(int $facilityId, int $userId): void;
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
@@ -2,7 +2,6 @@
 
 namespace App\Repositories\FacilityFavorite;
 
-use App\Models\FacilityFavorite;
 use Illuminate\Database\Eloquent\Collection;
 
 interface FacilityFavoriteRepositoryInterface

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
@@ -2,9 +2,11 @@
 
 namespace App\Repositories\FacilityFavorite;
 
+use App\Models\FacilityFavorite;
 use Illuminate\Database\Eloquent\Collection;
 
 interface FacilityFavoriteRepositoryInterface
 {
     public function getUserFacilityFavorities(int $id): Collection;
+    public function registerUserFacilityFavorite(int $facilityId, int $userId): bool;
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
@@ -7,6 +7,6 @@ use Illuminate\Database\Eloquent\Collection;
 interface FacilityFavoriteRepositoryInterface
 {
     public function getUserFacilityFavorites(int $id): Collection;
-    public function register(int $facilityId, int $userId): void;
-    public function cancel(int $facilityId, int $userId): void;
+    public function register(string $facilityId, int $userId): void;
+    public function cancel(string $facilityId, int $userId): void;
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 interface FacilityFavoriteRepositoryInterface
 {
-    public function getUserFacilityFavorities(int $id): Collection;
+    public function getUserFacilityFavorites(int $id): Collection;
     public function registerUserFacilityFavorite(int $facilityId, int $userId): bool;
     public function cancelUserFacilityFavorite(int $facilityId, int $userId): bool;
 }

--- a/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
+++ b/laravel/app/Repositories/FacilityFavorite/FacilityFavoriteRepositoryInterface.php
@@ -8,4 +8,5 @@ interface FacilityFavoriteRepositoryInterface
 {
     public function getUserFacilityFavorities(int $id): Collection;
     public function registerUserFacilityFavorite(int $facilityId, int $userId): bool;
+    public function cancelUserFacilityFavorite(int $facilityId, int $userId): bool;
 }

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -14,12 +14,12 @@ class FacilityFavoriteService
         $this->facilityFavoriteRepository = $facilityFavoriteRepository;
     }
 
-    public function getFacilityFavorities()
+    public function getFacilityFavorites()
     {
         $userId = Auth::id();
-        $userFacilityFavorities = $this->facilityFavoriteRepository->getUserFacilityFavorites($userId);
+        $userFacilityFavorites = $this->facilityFavoriteRepository->getUserFacilityFavorites($userId);
 
-        return $userFacilityFavorities->map(function ($facility) {
+        return $userFacilityFavorites->map(function ($facility) {
             $address = $facility?->address;
             $municipality = $address?->municipality;
             $prefecture = $municipality?->prefecture;

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -34,7 +34,7 @@ class FacilityFavoriteService
         })->toArray();
     }
 
-    public function registerFacilityFavorite(int $facilityId): void
+    public function register(int $facilityId): void
     {
         $userId = Auth::id();
         $this->facilityFavoriteRepository->register($facilityId, $userId);

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -39,4 +39,10 @@ class FacilityFavoriteService
         $userId = Auth::id();
         $this->facilityFavoriteRepository->registerUserFacilityFavorite($facilityId, $userId);
     }
+
+    public function cancelFacilityFavorite(int $facilityId)
+    {
+        $userId = Auth::id();
+        $this->facilityFavoriteRepository->cancelUserFacilityFavorite($facilityId, $userId);
+    }
 }

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -17,7 +17,7 @@ class FacilityFavoriteService
     public function getFacilityFavorities()
     {
         $userId = Auth::id();
-        $userFacilityFavorities = $this->facilityFavoriteRepository->getUserFacilityFavorities($userId);
+        $userFacilityFavorities = $this->facilityFavoriteRepository->getUserFacilityFavorites($userId);
 
         return $userFacilityFavorities->map(function ($facility) {
             $address = $facility?->address;
@@ -34,15 +34,15 @@ class FacilityFavoriteService
         })->toArray();
     }
 
-    public function registerFacilityFavorite(int $facilityId)
+    public function registerFacilityFavorite(int $facilityId): void
     {
         $userId = Auth::id();
-        $this->facilityFavoriteRepository->registerUserFacilityFavorite($facilityId, $userId);
+        $this->facilityFavoriteRepository->register($facilityId, $userId);
     }
 
-    public function cancelFacilityFavorite(int $facilityId)
+    public function cancel(int $facilityId): void
     {
         $userId = Auth::id();
-        $this->facilityFavoriteRepository->cancelUserFacilityFavorite($facilityId, $userId);
+        $this->facilityFavoriteRepository->cancel($facilityId, $userId);
     }
 }

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -33,4 +33,10 @@ class FacilityFavoriteService
             ];
         })->toArray();
     }
+
+    public function registerFacilityFavorite(int $facilityId)
+    {
+        $userId = Auth::id();
+        $this->facilityFavoriteRepository->registerUserFacilityFavorite($facilityId, $userId);
+    }
 }

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -34,13 +34,13 @@ class FacilityFavoriteService
         })->toArray();
     }
 
-    public function register(int $facilityId): void
+    public function register(string $facilityId): void
     {
         $userId = Auth::id();
         $this->facilityFavoriteRepository->register($facilityId, $userId);
     }
 
-    public function cancel(int $facilityId): void
+    public function cancel(string $facilityId): void
     {
         $userId = Auth::id();
         $this->facilityFavoriteRepository->cancel($facilityId, $userId);

--- a/laravel/app/Services/FacilityFavoriteService.php
+++ b/laravel/app/Services/FacilityFavoriteService.php
@@ -2,14 +2,14 @@
 
 namespace App\Services;
 
-use App\Repositories\FacilityFavorite\FacilityFavoriteRepository;
+use App\Repositories\FacilityFavorite\FacilityFavoriteRepositoryInterface;
 use Illuminate\Support\Facades\Auth;
 
 class FacilityFavoriteService
 {
-    private FacilityFavoriteRepository $facilityFavoriteRepository;
+    private FacilityFavoriteRepositoryInterface $facilityFavoriteRepository;
 
-    public function __construct(FacilityFavoriteRepository $facilityFavoriteRepository)
+    public function __construct(FacilityFavoriteRepositoryInterface $facilityFavoriteRepository)
     {
         $this->facilityFavoriteRepository = $facilityFavoriteRepository;
     }

--- a/laravel/app/Services/FacilityService.php
+++ b/laravel/app/Services/FacilityService.php
@@ -21,7 +21,7 @@ class FacilityService
         if ($user && $user->address) {
             $municipalityId = $user->address->municipality_id;
         } else {
-            $municipalityId = 1638;
+            $municipalityId = 1615;
         }
         return $this->facilityRepository->getAll($municipalityId, $name);
     }

--- a/laravel/app/Services/FacilityService.php
+++ b/laravel/app/Services/FacilityService.php
@@ -21,12 +21,12 @@ class FacilityService
         if ($user && $user->address) {
             $municipalityId = $user->address->municipality_id;
         } else {
-            $municipalityId = 1615;
+            $municipalityId = 1566;
         }
         return $this->facilityRepository->getAll($municipalityId, $name);
     }
 
-    public function find(int $id): Facility
+    public function find(string $id): Facility
     {
         return $this->facilityRepository->find($id);
     }

--- a/laravel/database/migrations/2025_12_29_170119_fix_facility_favorites_table.php
+++ b/laravel/database/migrations/2025_12_29_170119_fix_facility_favorites_table.php
@@ -47,7 +47,7 @@ return new class extends Migration
 
             $table->foreign('facility_id')
                   ->references('id')
-                  ->on('facility_favorites');
+                  ->on('facilities');
         });
     }
 };

--- a/laravel/database/migrations/2025_12_29_170119_fix_facility_favorites_table.php
+++ b/laravel/database/migrations/2025_12_29_170119_fix_facility_favorites_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('facility_favorites', function (Blueprint $table) {
+            $table->dropForeign(['facility_id']);
+
+            $table->dropColumn('deleted_at');
+
+            $table->unique(['user_id', 'facility_id']);
+
+            $table->unsignedBigInteger('facility_id')
+                  ->comment('施設ID')
+                  ->change();
+
+            $table->foreign('facility_id')
+                  ->references('id')
+                  ->on('facilities')
+                  ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('facility_favorites', function (Blueprint $table) {
+            $table->dropForeign(['facility_id']);
+
+            $table->dropUnique(['facility_favorites_user_id_facility_id_unique']);
+
+            $table->unsignedBigInteger('facility_id')
+                ->comment('お気に入り施設')
+                ->change();
+
+            $table->softDeletes();
+
+            $table->foreign('facility_id')
+                  ->references('id')
+                  ->on('facility_favorites');
+        });
+    }
+};

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -31,6 +31,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/calendar/events', [CalenderController::class, 'index']);
 
     Route::get('/favorites', [FavoriteController::class, 'index']);
+    Route::post('/facilities/{id}/favorite', [FavoriteController::class, 'store']);
+    Route::delete('/facilities/{id}/favorite', [FavoriteController::class, 'destroy']);
 });
 
 Route::post('/login', [AuthController::class, 'login']);

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -27,7 +27,8 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/facilities', [FacilityController::class, 'index']);
     Route::post('/facilities/{facilityId}/favorite', [FavoriteController::class, 'store'])->whereNumber('facilityId');
-    Route::delete('/facilities/{facilityId}/favorite', [FavoriteController::class, 'destroy'])->whereNumber('facilityId');
+    Route::delete('/facilities/{facilityId}/favorite', [FavoriteController::class, 'destroy'])
+            ->whereNumber('facilityId');
     Route::get('/facilities/{facilityId}', [FacilityController::class, 'show'])->whereNumber('facilityId');
 
     Route::get('/calendar/events', [CalenderController::class, 'index']);

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -26,10 +26,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/profile', [UserController::class, 'profile']);
 
     Route::get('/facilities', [FacilityController::class, 'index']);
-    Route::post('/facilities/{facilityId}/favorite', [FavoriteController::class, 'store'])->whereNumber('facilityId');
-    Route::delete('/facilities/{facilityId}/favorite', [FavoriteController::class, 'destroy'])
-            ->whereNumber('facilityId');
-    Route::get('/facilities/{facilityId}', [FacilityController::class, 'show'])->whereNumber('facilityId');
+    Route::post('/facilities/{facilityId}/favorite', [FavoriteController::class, 'store']);
+    Route::delete('/facilities/{facilityId}/favorite', [FavoriteController::class, 'destroy']);
+    Route::get('/facilities/{facilityId}', [FacilityController::class, 'show']);
 
     Route::get('/calendar/events', [CalenderController::class, 'index']);
 

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -26,13 +26,13 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/profile', [UserController::class, 'profile']);
 
     Route::get('/facilities', [FacilityController::class, 'index']);
-    Route::get('/facilities/{id}', [FacilityController::class, 'show']);
+    Route::post('/facilities/{facilityId}/favorite', [FavoriteController::class, 'store'])->whereNumber('facilityId');
+    Route::delete('/facilities/{facilityId}/favorite', [FavoriteController::class, 'destroy'])->whereNumber('facilityId');
+    Route::get('/facilities/{facilityId}', [FacilityController::class, 'show'])->whereNumber('facilityId');
 
     Route::get('/calendar/events', [CalenderController::class, 'index']);
 
     Route::get('/favorites', [FavoriteController::class, 'index']);
-    Route::post('/facilities/{id}/favorite', [FavoriteController::class, 'store']);
-    Route::delete('/facilities/{id}/favorite', [FavoriteController::class, 'destroy']);
 });
 
 Route::post('/login', [AuthController::class, 'login']);

--- a/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
+++ b/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
@@ -39,7 +39,7 @@ class FacilityFavoriteRepositoryTest extends TestCase
         $user1->facilityFavorities()->attach($facility1->id);
         $user2->facilityFavorities()->attach($facility2->id);
 
-        $result = $this->facilityFavoriteRepository->getUserFacilityFavorities($user1->id);
+        $result = $this->facilityFavoriteRepository->getUserFacilityFavorites($user1->id);
 
         $this->assertCount(1, $result);
         $this->assertEquals($facility1->id, $result->first()->id);
@@ -54,7 +54,7 @@ class FacilityFavoriteRepositoryTest extends TestCase
         $user = User::factory()->create();
         $facility = Facility::factory()->create();
 
-        $this->facilityFavoriteRepository->registerUserFacilityFavorite($facility->id, $user->id);
+        $this->facilityFavoriteRepository->register($facility->id, $user->id);
 
         $this->assertDatabaseHas('facility_favorites', [
             'user_id' => $user->id,
@@ -71,7 +71,7 @@ class FacilityFavoriteRepositoryTest extends TestCase
         $user = User::factory()->create();
         $facility = Facility::factory()->create();
 
-        $this->facilityFavoriteRepository->cancelUserFacilityFavorite($facility->id, $user->id);
+        $this->facilityFavoriteRepository->cancel($facility->id, $user->id);
 
         $this->assertDatabaseMissing('facility_favorites', [
             'user_id' => $user->id,

--- a/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
+++ b/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
@@ -28,7 +28,7 @@ class FacilityFavoriteRepositoryTest extends TestCase
      * @test
      */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function getUserFacilityFavoritiesはそのユーザーの施設だけ返す(): void
+    public function getUserFacilityFavoritesはそのユーザーの施設だけ返す(): void
     {
         $user1 = User::factory()->create();
         $user2 = User::factory()->create();

--- a/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
+++ b/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
@@ -24,7 +24,10 @@ class FacilityFavoriteRepositoryTest extends TestCase
         $this->facilityFavoriteRepository = app(FacilityFavoriteRepositoryInterface::class);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
     public function getUserFacilityFavoritiesはそのユーザーの施設だけ返す(): void
     {
         $user1 = User::factory()->create();

--- a/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
+++ b/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
@@ -36,8 +36,8 @@ class FacilityFavoriteRepositoryTest extends TestCase
         $facility1 = Facility::factory()->create();
         $facility2 = Facility::factory()->create();
 
-        $user1->facilityFavorities()->attach($facility1->id);
-        $user2->facilityFavorities()->attach($facility2->id);
+        $user1->facilityFavorites()->attach($facility1->id);
+        $user2->facilityFavorites()->attach($facility2->id);
 
         $result = $this->facilityFavoriteRepository->getUserFacilityFavorites($user1->id);
 

--- a/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
+++ b/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Repositories\FacilityFavorite;
+
+use App\Models\Facility;
+use App\Models\User;
+use App\Repositories\FacilityFavorite\FacilityFavoriteRepository;
+use App\Repositories\FacilityFavorite\FacilityFavoriteRepositoryInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FacilityFavoriteRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FacilityFavoriteRepositoryInterface $facilityFavoriteRepository;
+    /**
+     * A basic unit test example.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()->bind(FacilityFavoriteRepositoryInterface::class, FacilityFavoriteRepository::class);
+        $this->facilityFavoriteRepository = app(FacilityFavoriteRepositoryInterface::class);
+    }
+
+    /** @test */
+    public function getUserFacilityFavoritiesはそのユーザーの施設だけ返す(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+
+        $facility1 = Facility::factory()->create();
+        $facility2 = Facility::factory()->create();
+
+        $user1->facilityFavorities()->attach($facility1->id);
+        $user2->facilityFavorities()->attach($facility2->id);
+
+        $result = $this->facilityFavoriteRepository->getUserFacilityFavorities($user1->id);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($facility1->id, $result->first()->id);
+    }
+
+    /**
+     * @test
+     */
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function registerUserFacilityFavoriteで中間テーブルにレコードが追加されること(): void
+    {
+        $user = User::factory()->create();
+        $facility = Facility::factory()->create();
+
+        $this->facilityFavoriteRepository->registerUserFacilityFavorite($facility->id, $user->id);
+
+        $this->assertDatabaseHas('facility_favorites', [
+            'user_id' => $user->id,
+            'facility_id' => $facility->id,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function cancelUserFacilityFavoriteで中間テーブルにレコードが削除されること(): void
+    {
+        $user = User::factory()->create();
+        $facility = Facility::factory()->create();
+
+        $this->facilityFavoriteRepository->cancelUserFacilityFavorite($facility->id, $user->id);
+
+        $this->assertDatabaseMissing('facility_favorites', [
+            'user_id' => $user->id,
+            'facility_id' => $facility->id,
+        ]);
+    }
+}

--- a/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
+++ b/laravel/tests/Unit/Repositories/FacilityFavorite/FacilityFavoriteRepositoryTest.php
@@ -49,7 +49,26 @@ class FacilityFavoriteRepositoryTest extends TestCase
      * @test
      */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function registerUserFacilityFavoriteで中間テーブルにレコードが追加されること(): void
+    public function 二回同じuserId、facilityIdでregisterが実行されたときに、レコードが1つのままであること(): void
+    {
+        $user1 = User::factory()->create();
+
+        $facility1 = Facility::factory()->create();
+
+        $this->facilityFavoriteRepository->register($facility1->id, $user1->id);
+        $this->facilityFavoriteRepository->register($facility1->id, $user1->id);
+
+        $this->assertDatabaseCount('facility_favorites', 1);
+        $this->assertDatabaseHas('facility_favorites', [
+            'user_id' => $user1->id,
+            'facility_id' => $facility1->id,
+        ]);
+    }
+    /**
+     * @test
+     */
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function registerで中間テーブルにレコードが追加されること(): void
     {
         $user = User::factory()->create();
         $facility = Facility::factory()->create();
@@ -66,12 +85,16 @@ class FacilityFavoriteRepositoryTest extends TestCase
      * @test
      */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function cancelUserFacilityFavoriteで中間テーブルにレコードが削除されること(): void
+    public function cancelで中間テーブルにレコードが削除されること(): void
     {
         $user = User::factory()->create();
         $facility = Facility::factory()->create();
 
+        $user->facilityFavorites()->syncWithoutDetaching($facility->id);
+
         $this->facilityFavoriteRepository->cancel($facility->id, $user->id);
+
+        $this->assertDatabaseCount('facility_favorites', 0);
 
         $this->assertDatabaseMissing('facility_favorites', [
             'user_id' => $user->id,

--- a/laravel/tests/Unit/Services/FacilityFavorite/FacilityFavoriteServiceTest.php
+++ b/laravel/tests/Unit/Services/FacilityFavorite/FacilityFavoriteServiceTest.php
@@ -31,11 +31,11 @@ class FacilityFavoriteServiceTest extends TestCase
     {
         Auth::shouldReceive('id')->once()->andReturn(1);
         $this->facilityFavoriteRepositoryMock
-             ->shouldReceive('registerUserFacilityFavorite')
+             ->shouldReceive('register')
              ->once()
              ->with(123, 1);
 
-        $this->facilityFavoriteService->registerFacilityFavorite(123);
+        $this->facilityFavoriteService->register(123);
 
         $this->assertTrue(true);
     }
@@ -48,11 +48,11 @@ class FacilityFavoriteServiceTest extends TestCase
     {
         Auth::shouldReceive('id')->once()->andReturn(1);
         $this->facilityFavoriteRepositoryMock
-             ->shouldReceive('cancelUserFacilityFavorite')
+             ->shouldReceive('cancel')
              ->once()
              ->with(123, 1);
 
-        $this->facilityFavoriteService->cancelFacilityFavorite(123);
+        $this->facilityFavoriteService->cancel(123);
         $this->assertTrue(true);
     }
 }

--- a/laravel/tests/Unit/Services/FacilityFavorite/FacilityFavoriteServiceTest.php
+++ b/laravel/tests/Unit/Services/FacilityFavorite/FacilityFavoriteServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Services\FacilityFavorite;
+
+use App\Models\Facility;
+use App\Repositories\FacilityFavorite\FacilityFavoriteRepositoryInterface;
+use App\Services\FacilityFavoriteService;
+use Barryvdh\LaravelIdeHelper\Eloquent;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class FacilityFavoriteServiceTest extends TestCase
+{
+    /** @var FacilityFavoriteRepositoryInterface&\Mockery\MockInterface $facilityFavoriteRepositoryMock */
+    private $facilityFavoriteRepositoryMock;
+    private FacilityFavoriteService $facilityFavoriteService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->facilityFavoriteRepositoryMock = $this->mock(FacilityFavoriteRepositoryInterface::class);
+        $this->facilityFavoriteService = new FacilityFavoriteService($this->facilityFavoriteRepositoryMock);
+    }
+
+    /**
+     * @test
+     */
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function registerFacilityFavoriteメソッドが認証ユーザーidでRepositoryを呼べること(): void
+    {
+        Auth::shouldReceive('id')->once()->andReturn(1);
+        $this->facilityFavoriteRepositoryMock
+             ->shouldReceive('registerUserFacilityFavorite')
+             ->once()
+             ->with(123, 1);
+
+        $this->facilityFavoriteService->registerFacilityFavorite(123);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function cancelFacilityFavoriteメソッドが認証ユーザーidでRepositoryを呼べること(): void
+    {
+        Auth::shouldReceive('id')->once()->andReturn(1);
+        $this->facilityFavoriteRepositoryMock
+             ->shouldReceive('cancelUserFacilityFavorite')
+             ->once()
+             ->with(123, 1);
+
+        $this->facilityFavoriteService->cancelFacilityFavorite(123);
+        $this->assertTrue(true);
+    }
+}

--- a/laravel/tests/Unit/Services/FacilityFavorite/FacilityFavoriteServiceTest.php
+++ b/laravel/tests/Unit/Services/FacilityFavorite/FacilityFavoriteServiceTest.php
@@ -27,7 +27,7 @@ class FacilityFavoriteServiceTest extends TestCase
      * @test
      */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function registerFacilityFavoriteメソッドが認証ユーザーidでRepositoryを呼べること(): void
+    public function registerメソッドが認証ユーザーidでRepositoryを呼べること(): void
     {
         Auth::shouldReceive('id')->once()->andReturn(1);
         $this->facilityFavoriteRepositoryMock
@@ -44,7 +44,7 @@ class FacilityFavoriteServiceTest extends TestCase
      * @test
      */
     // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    public function cancelFacilityFavoriteメソッドが認証ユーザーidでRepositoryを呼べること(): void
+    public function cancelメソッドが認証ユーザーidでRepositoryを呼べること(): void
     {
         Auth::shouldReceive('id')->once()->andReturn(1);
         $this->facilityFavoriteRepositoryMock


### PR DESCRIPTION
## 概要

<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->
https://www.notion.so/25e2946467fd8010b05ec4f0e69c44b0?v=25e2946467fd80399d32000c8c8893ba&p=2d12946467fd803c8a55f6b5c2647ddc&pm=s
## 詳細
- Contoroller・Service・Repositoryに分けて施設お気に入り登録と、施設お気に入り解除の実装を行った。
- 各メソッドの命名
- ServiceとRepositoryで適切に責務が分けられているか。
- 例外処理が全般的にうまくいっていなくて、たとえば404エラー自体は返却されるんやけど、Laravel の 404 を勝手に投げて Controller の JSON を殺している状態らしい。例外処理の実装面を教えて欲しい。
（原因はfindOrFailを多用しているかららしいけど、どう改善すればいいのかがわからない。storeアクションの引数のintを消したり、chat曰くfindに変えて、直後にif文でたとえばif (! user) return falseみたいにすればいいって出たけどやってもうまくいかなかった。）これが直らないと、開発者ツールで`http://localhost:8000/api/facilities/aaaaa/favorite`とか、存在しない施設IDの時に問題が出てきちゃいそう。

- 今すぐに直すのは難しいけど、laravel/app/Models/Facility.phpの98~120行目がかなり怪しい感じがする。
<!--
レビュアーに重点的に見て欲しい内容を書きましょう  
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです  
-->

## 動作確認
### お気に入り登録前
<img width="1440" height="900" alt="スクリーンショット 2025-12-31 20 57 59" src="https://github.com/user-attachments/assets/171a7a2c-43e0-489d-b377-4592b191f6fb" />

### お気に入り登録API実行後
<img width="1440" height="900" alt="スクリーンショット 2025-12-31 20 58 10" src="https://github.com/user-attachments/assets/03b19893-2220-40f5-b894-ce886861aebc" />

### お気に入り解除API実行
<img width="1440" height="900" alt="スクリーンショット 2025-12-31 20 59 51" src="https://github.com/user-attachments/assets/9d5b719d-a15a-4eeb-97bf-ec05a5683a03" />

### お気に入り解除後
<img width="1440" height="900" alt="スクリーンショット 2025-12-31 21 00 06" src="https://github.com/user-attachments/assets/01e7040f-54e6-4fac-80df-b7372c0ae590" />

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう  
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->

## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
